### PR TITLE
Bubble up errors and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,17 @@ Here is what your bot's `main.go` should look like:
 package main
 
 import (
+	"os"
+
 	gadget "github.com/gadget-bot/gadget/core"
 	"github.com/gadget-bot/gadget/plugins/how"
 )
 
 func main() {
-	myBot := gadget.Setup()
+	myBot, err := gadget.Setup()
+	if err != nil {
+		os.Exit(1)
+	}
 
 	// Add your custom mention plugins here
   
@@ -121,7 +126,10 @@ From there, we can just extend the `main.go` above, changing the `func main()` t
 
 ```golang
 func main() {
-	myBot := gadget.Setup()
+	myBot, err := gadget.Setup()
+	if err != nil {
+		os.Exit(1)
+	}
 
 	// Add your custom mention plugins here
   

--- a/main.go
+++ b/main.go
@@ -1,14 +1,21 @@
 package main
 
 import (
+	"os"
+
 	gadget "github.com/gadget-bot/gadget/core"
 )
 
 func main() {
-	myBot := gadget.Setup()
+	myBot, err := gadget.Setup()
+	if err != nil {
+		println(err.Error())
+		os.Exit(1)
+	}
 
 	// Add your custom plugins here
 
 	// This launches your bot
+
 	myBot.Run()
 }


### PR DESCRIPTION
Bubble up errors instead of panicking to allow wrapping application the ability to print helpful messages.