### PR TITLE
Initialize channelmessages map

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -32,6 +32,7 @@ type Router struct {
 func NewRouter() *Router {
 	var newRouter Router
 	newRouter.MentionRoutes = make(map[string]MentionRoute)
+	newRouter.ChannelMessageRoutes = make(map[string]ChannelMessageRoute)
 	return &newRouter
 }
 


### PR DESCRIPTION
Initialize `ChannelMessages` field in `NewRouter()`.