### PR TITLE
Add route introspection API

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -21,10 +21,15 @@ type Route struct {
 	Priority    int
 }
 
+const (
+	RouteTypeMention        = "mention"
+	RouteTypeChannelMessage = "channel_message"
+)
+
 // RegisteredRoute wraps a Route with its type for introspection
 type RegisteredRoute struct {
 	Route
-	Type string // "mention" or "channel_message"
+	Type string // RouteTypeMention or RouteTypeChannelMessage
 }
 
 //Router the HTTP router which handles Events from Slack
@@ -220,15 +225,16 @@ func (router Router) AddChannelMessageRoutes(routes []ChannelMessageRoute) {
 }
 
 // RegisteredRoutes returns all registered routes sorted by priority (descending),
-// then by name (alphabetical). DefaultMentionRoute and DeniedMentionRoute are excluded.
+// then by name (alphabetical). DefaultMentionRoute and DeniedMentionRoute are excluded
+// because they are stored as separate struct fields, not entries in the route maps.
 func (router Router) RegisteredRoutes() []RegisteredRoute {
 	routes := make([]RegisteredRoute, 0, len(router.MentionRoutes)+len(router.ChannelMessageRoutes))
 
 	for _, r := range router.MentionRoutes {
-		routes = append(routes, RegisteredRoute{Route: r.Route, Type: "mention"})
+		routes = append(routes, RegisteredRoute{Route: r.Route, Type: RouteTypeMention})
 	}
 	for _, r := range router.ChannelMessageRoutes {
-		routes = append(routes, RegisteredRoute{Route: r.Route, Type: "channel_message"})
+		routes = append(routes, RegisteredRoute{Route: r.Route, Type: RouteTypeChannelMessage})
 	}
 
 	sort.Slice(routes, func(i, j int) bool {

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -28,8 +28,8 @@ func TestRegisteredRoutes_IncludesBothTypes(t *testing.T) {
 	for _, route := range routes {
 		types[route.Type] = true
 	}
-	assert.True(t, types["mention"])
-	assert.True(t, types["channel_message"])
+	assert.True(t, types[RouteTypeMention])
+	assert.True(t, types[RouteTypeChannelMessage])
 }
 
 func TestRegisteredRoutes_SortedByPriorityDescending(t *testing.T) {
@@ -102,5 +102,5 @@ func TestRegisteredRoutes_PreservesMetadata(t *testing.T) {
 	assert.Equal(t, "Say 'test' to test", routes[0].Help)
 	assert.Equal(t, []string{"admins"}, routes[0].Permissions)
 	assert.Equal(t, 5, routes[0].Priority)
-	assert.Equal(t, "mention", routes[0].Type)
+	assert.Equal(t, RouteTypeMention, routes[0].Type)
 }


### PR DESCRIPTION
## Summary
- Add `RegisteredRoute` struct that wraps `Route` with a `Type` field (`"mention"` or `"channel_message"`)
- Add `RegisteredRoutes()` method on `Router` that returns all registered routes sorted by priority (desc), then name (asc)
- Internal routes (DefaultMentionRoute, DeniedMentionRoute) are excluded

Enables building self-documenting commands like `/help` or `/diagnostics`.

Closes #18

## Test plan
- [x] `go test -v ./router/` — 6 new tests covering empty router, both route types, priority sorting, name tiebreaking, default/denied exclusion, and metadata preservation