### PR TITLE
Add DeniedSlashCommandRoute and unknown command response

### DIFF
--- a/plugins/permission_denied/permission_denied.go
+++ b/plugins/permission_denied/permission_denied.go
@@ -2,6 +2,7 @@ package permission_denied
 
 import (
 	"github.com/gadget-bot/gadget/router"
+	"github.com/rs/zerolog/log"
 
 	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/slackevents"
@@ -18,6 +19,16 @@ func GetMentionRoute() *router.MentionRoute {
 			ev.Channel,
 			slack.MsgOptionText("I'm sorry, <@"+ev.User+">, but you're not allowed to do that.", false),
 		)
+	}
+	return &pluginRoute
+}
+
+func GetSlashCommandRoute() *router.SlashCommandRoute {
+	var pluginRoute router.SlashCommandRoute
+	pluginRoute.Permissions = append(pluginRoute.Permissions, "*")
+	pluginRoute.Name = "permission_denied"
+	pluginRoute.Plugin = func(r router.Router, route router.Route, api slack.Client, cmd slack.SlashCommand) {
+		log.Warn().Str("user", cmd.UserID).Str("command", cmd.Command).Msg("Slash command permission denied")
 	}
 	return &pluginRoute
 }

--- a/router/router.go
+++ b/router/router.go
@@ -38,10 +38,11 @@ type Router struct {
 	MentionRoutes        map[string]MentionRoute
 	ChannelMessageRoutes map[string]ChannelMessageRoute
 	SlashCommandRoutes   map[string]SlashCommandRoute
-	DefaultMentionRoute  MentionRoute
-	DeniedMentionRoute   MentionRoute
-	DbConnection         *gorm.DB
-	BotUID               string
+	DefaultMentionRoute      MentionRoute
+	DeniedMentionRoute       MentionRoute
+	DeniedSlashCommandRoute  SlashCommandRoute
+	DbConnection             *gorm.DB
+	BotUID                   string
 }
 
 // this is required because slack-go doesn't seem to provide a way to get the bot's own ID


### PR DESCRIPTION
## Summary
- Add `DeniedSlashCommandRoute` field to `Router` and implement `GetSlashCommandRoute()` in the permission_denied plugin (#26)
- Fire `DeniedSlashCommandRoute` plugin in a goroutine on slash command permission denial
- Return ephemeral `"Unknown command."` for unregistered slash commands (#24)

Closes #26, closes #24

## Test plan
- [x] `make test` passes
- [x] `make build` succeeds