### PR TITLE
Add configurable log level and GORM query logging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ Routes are added via `Router.AddMentionRoute()` / `Router.AddMentionRoutes()` an
 
 ### Configuration
 
-Environment variables: `SLACK_OAUTH_TOKEN`, `SLACK_SIGNING_SECRET`, `GADGET_GLOBAL_ADMINS` (comma-separated user IDs), `GADGET_DB_USER`, `GADGET_DB_PASS`, `GADGET_DB_HOST`, `GADGET_DB_NAME`, `GADGET_LISTEN_PORT` (default 3000).
+Environment variables: `SLACK_OAUTH_TOKEN`, `SLACK_SIGNING_SECRET`, `GADGET_GLOBAL_ADMINS` (comma-separated user IDs), `GADGET_DB_USER`, `GADGET_DB_PASS`, `GADGET_DB_HOST`, `GADGET_DB_NAME`, `GADGET_LISTEN_PORT` (default 3000), `GADGET_LOG_LEVEL` (default `info`; valid values: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic`).
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary
- Add `GADGET_LOG_LEVEL` env var support (default: `info`) using `zerolog.ParseLevel`
- Configure GORM logger based on log level: debug mode shows all queries, otherwise only slow queries/warnings
- Log level is set early in `Setup()` before any other log calls

Depends on #46
Closes #44

## Test plan
- [x] `make test` — all existing tests pass
- [ ] Manual: run with `GADGET_LOG_LEVEL=debug` and confirm GORM queries appear
- [ ] Manual: run with `GADGET_LOG_LEVEL=warn` and confirm debug/info logs are suppressed