### PR TITLE
Clean up else-after-return style violations

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -104,9 +104,8 @@ func verifySlackRequest(w http.ResponseWriter, r *http.Request, logger zerolog.L
 func getListenPort() string {
 	if listenPort != "" {
 		return listenPort
-	} else {
-		return "3000"
 	}
+	return "3000"
 }
 
 func globalAdminsFromString(admins string) []string {

--- a/router/router.go
+++ b/router/router.go
@@ -186,31 +186,26 @@ func (router Router) Can(u models.User, permissions []string) bool {
 	}
 
 	if isAllowed {
-		return isAllowed
-	} else if len(permissions) == 0 {
+		return true
+	}
+	if len(permissions) == 0 {
 		// if no permissions are defined, assume it is open/allow all
 		return true
-	} else {
-		for _, groupName := range permissions {
-			// If everyone is allowed, stop checking
-			if groupName == "*" {
-				isAllowed = true
-				break
-			}
+	}
+	for _, groupName := range permissions {
+		// If everyone is allowed, stop checking
+		if groupName == "*" {
+			return true
+		}
 
-			// user groups _must_ be smaller than all groups
-			for _, userGroup := range userGroupNames {
-				if groupName == userGroup {
-					isAllowed = true
-					break
-				}
-			}
-			if isAllowed {
-				break
+		// user groups _must_ be smaller than all groups
+		for _, userGroup := range userGroupNames {
+			if groupName == userGroup {
+				return true
 			}
 		}
 	}
-	return isAllowed
+	return false
 }
 
 // AddMentionRoute sets upserts and element into `MentionRoutes` whose key is the provided `Name` field


### PR DESCRIPTION
## Summary

- Flatten else-after-return in `getListenPort()` (core/core.go) and `Can()` (router/router.go) to follow Go style conventions
- Simplify `Can()` control flow by returning directly from each permission check branch, eliminating the `isAllowed` tracking variable after the globalAdmins check

## Related Issues

- Closes #65 (else-after-return cleanup)
- Closes #63 (testify indirect annotation — already fixed in current go.mod, `go mod tidy` produces no changes)
- References #64 (`go mod tidy` — no changes needed, dependency already correct)
- Part of milestone v0.7.0

## Test plan

- [x] `make test` passes (all existing tests pass with no changes needed)
- [x] `make build` succeeds