### PR TITLE
Fix plugin tests for compiled route patterns

### DIFF
--- a/plugins/groups/group_management_test.go
+++ b/plugins/groups/group_management_test.go
@@ -3,6 +3,7 @@ package groups
 import (
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"testing"
 
 	"github.com/gadget-bot/gadget/models"
@@ -27,6 +28,11 @@ func setupGroupTestDB(t *testing.T) *gorm.DB {
 		t.Fatalf("Failed to auto-migrate: %v", err)
 	}
 	return db
+}
+
+func compileMentionRouteForTest(t *testing.T, route *router.MentionRoute) {
+	t.Helper()
+	route.CompiledPattern = regexp.MustCompile(route.Pattern)
 }
 
 func TestGetMentionRoutes_ReturnsAllRoutes(t *testing.T) {
@@ -175,6 +181,7 @@ func TestAddUserToGroup_AddsSuccessfully(t *testing.T) {
 	api := slack.New("xoxb-fake", slack.OptionAPIURL(server.URL+"/"))
 
 	route := addUserToGroup()
+	compileMentionRouteForTest(t, route)
 	r := router.Router{DbConnection: db}
 	ev := slackevents.AppMentionEvent{
 		User:      "U_ADMIN",
@@ -220,6 +227,7 @@ func TestRemoveUserFromGroup_RemovesSuccessfully(t *testing.T) {
 	api := slack.New("xoxb-fake", slack.OptionAPIURL(server.URL+"/"))
 
 	route := removeUserFromGroup()
+	compileMentionRouteForTest(t, route)
 	r := router.Router{DbConnection: db}
 	ev := slackevents.AppMentionEvent{
 		User:      "U_ADMIN",
@@ -253,6 +261,7 @@ func TestRemoveUserFromGroup_NonexistentGroup(t *testing.T) {
 	api := slack.New("xoxb-fake", slack.OptionAPIURL(server.URL+"/"))
 
 	route := removeUserFromGroup()
+	compileMentionRouteForTest(t, route)
 	r := router.Router{DbConnection: db}
 	ev := slackevents.AppMentionEvent{
 		User:      "U_ADMIN",
@@ -325,6 +334,7 @@ func TestAddUserToGroup_UserAlreadyInGroup(t *testing.T) {
 	api := slack.New("xoxb-fake", slack.OptionAPIURL(server.URL+"/"))
 
 	route := addUserToGroup()
+	compileMentionRouteForTest(t, route)
 	r := router.Router{DbConnection: db}
 	ev := slackevents.AppMentionEvent{
 		User:      "U_ADMIN",
@@ -364,6 +374,7 @@ func TestRemoveUserFromGroup_UserNotAMember(t *testing.T) {
 	api := slack.New("xoxb-fake", slack.OptionAPIURL(server.URL+"/"))
 
 	route := removeUserFromGroup()
+	compileMentionRouteForTest(t, route)
 	r := router.Router{DbConnection: db}
 	ev := slackevents.AppMentionEvent{
 		User:      "U_ADMIN",

--- a/plugins/user_info/user_info_test.go
+++ b/plugins/user_info/user_info_test.go
@@ -3,6 +3,7 @@ package user_info
 import (
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"testing"
 
 	"github.com/gadget-bot/gadget/models"
@@ -27,6 +28,11 @@ func setupUserInfoTestDB(t *testing.T) *gorm.DB {
 		t.Fatalf("Failed to auto-migrate: %v", err)
 	}
 	return db
+}
+
+func compileMentionRouteForTest(t *testing.T, route *router.MentionRoute) {
+	t.Helper()
+	route.CompiledPattern = regexp.MustCompile(route.Pattern)
 }
 
 func TestGetMentionRoutes_ReturnsOneRoute(t *testing.T) {
@@ -79,6 +85,7 @@ func TestUserInfoPlugin_PostsUserDetails(t *testing.T) {
 	api := slack.New("xoxb-fake", slack.OptionAPIURL(server.URL+"/"))
 
 	route := userInfo()
+	compileMentionRouteForTest(t, route)
 	r := router.Router{DbConnection: db}
 	ev := slackevents.AppMentionEvent{
 		User:    "U_ADMIN",
@@ -114,6 +121,7 @@ func TestUserInfoPlugin_UserNotFound(t *testing.T) {
 	api := slack.New("xoxb-fake", slack.OptionAPIURL(server.URL+"/"))
 
 	route := userInfo()
+	compileMentionRouteForTest(t, route)
 	r := router.Router{DbConnection: db}
 	ev := slackevents.AppMentionEvent{
 		User:    "U_ADMIN",


### PR DESCRIPTION
## Summary
- compile mention route patterns in plugin tests that invoke plugin handlers directly, so `route.CompiledPattern` is initialized before `FindStringSubmatch`
- add small test-only helpers in groups and user_info plugin test files and apply them to regex-dependent test cases
- run `go mod tidy` to address #64; no dependency changes were needed because `testify` is already a direct dependency

## Validation
- `make test`

## Notes
- aligns with #68 route-registration regex hardening behavior while keeping this fix scoped to test setup
- #64 appears already satisfied on current `main` state