### PR TITLE
fix(conf): add conf package for build-time version injection

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -1,0 +1,8 @@
+// Package conf holds build-time configuration injected via ldflags.
+package conf
+
+// Executable is the name of the binary, set at build time via -ldflags.
+var Executable = "gadget"
+
+// GitVersion is the git version string, set at build time via -ldflags.
+var GitVersion = "dev"

--- a/main.go
+++ b/main.go
@@ -2,11 +2,17 @@ package main
 
 import (
 	gadget "github.com/gadget-bot/gadget/core"
+	"github.com/gadget-bot/gadget/conf"
 
 	"github.com/rs/zerolog/log"
 )
 
 func main() {
+	log.Info().
+		Str("executable", conf.Executable).
+		Str("version", conf.GitVersion).
+		Msg("Starting")
+
 	myBot, err := gadget.Setup()
 	if err != nil {
 		log.Fatal().Err(err).Msg("Setup failed")


### PR DESCRIPTION
## Summary
Create the missing `conf/` package to enable build-time version injection via ldflags.

## Changes
- Create `conf/conf.go` with `Executable` and `GitVersion` variables
- Add startup log showing version info in `main.go`

## Fixes
Closes #96

## Testing
- Code compiles successfully
- Version info is logged at startup