### PR TITLE
fix: apply gofmt formatting to router.go

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -37,15 +37,15 @@ type RegisteredRoute struct {
 
 // Router the HTTP router which handles Events from Slack
 type Router struct {
-	MentionRoutes           map[string]MentionRoute
-	ChannelMessageRoutes    map[string]ChannelMessageRoute
-	SlashCommandRoutes      map[string]SlashCommandRoute
-	DefaultMentionRoute     MentionRoute
-	DeniedMentionRoute          MentionRoute
-	DeniedChannelMessageRoute   ChannelMessageRoute
-	DeniedSlashCommandRoute     SlashCommandRoute
-	DbConnection            *gorm.DB
-	BotUID                  string
+	MentionRoutes             map[string]MentionRoute
+	ChannelMessageRoutes      map[string]ChannelMessageRoute
+	SlashCommandRoutes        map[string]SlashCommandRoute
+	DefaultMentionRoute       MentionRoute
+	DeniedMentionRoute        MentionRoute
+	DeniedChannelMessageRoute ChannelMessageRoute
+	DeniedSlashCommandRoute   SlashCommandRoute
+	DbConnection              *gorm.DB
+	BotUID                    string
 }
 
 // this is required because slack-go doesn't seem to provide a way to get the bot's own ID


### PR DESCRIPTION
Fixes #97

Applied gofmt to fix struct field alignment in router.go

## Changes
- Fixed alignment of Router struct fields in router/router.go
- All fields now properly aligned according to gofmt standards

## Testing
- Ran `gofmt -w .` to apply standard formatting
- Verified all other files already compliant