### PR TITLE
Modernize Makefile and expand golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,14 @@
 version: "2"
 
+formatters:
+  enable:
+    - goimports
 linters:
   default: none
   enable:
+    - errcheck
     - govet
+    - ineffassign
     - staticcheck
     - unused
-    - ineffassign
+    - zerologlint

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,15 @@
-COMMIT_HASH ?= $(shell git rev-parse --short HEAD 2>/dev/null)
-GITVERSION  ?= $(shell git describe --tags --exact-match 2>/dev/null || git describe --tags 2>/dev/null || echo "v0.0.0-$(COMMIT_HASH)")
-
 GO          ?= go
 GOOS        ?= $(shell $(GO) env GOOS)
 GOARCH      ?= $(shell $(GO) env GOARCH)
-PACKAGENAME := $(shell go list -m -f '{{.Path}}')
-GOLDFLAGS   ?= -s -w -X $(PACKAGENAME)/conf.Executable=$(EXECUTABLE) -X $(PACKAGENAME)/conf.GitVersion=$(GITVERSION)
-GOBUILD     ?= CGO_ENABLED=0 $(GO) build -ldflags="$(GOLDFLAGS)"
-GO_FILES    := $(shell find . -type f -name '*.go')
+PACKAGENAME := $(shell $(GO) list -m -f '{{.Path}}')
+GOBUILD     ?= CGO_ENABLED=0 $(GO) build
+GO_FILES    := $(shell find . -type f -name '*.go' -not -path './vendor/*')
 
 EXECUTABLE  := gadget
 ARTIFACT    := dist/$(GOOS)-$(GOARCH)/$(EXECUTABLE)
 
-DB_PASS      ?= $(shell openssl rand -hex 16)
-DB_ROOT_PASS ?= $(shell openssl rand -hex 16)
+DB_PASS      ?= gadget
+DB_ROOT_PASS ?= gadget
 
 .PHONY: all
 all: clean verify lint test build
@@ -21,11 +17,11 @@ all: clean verify lint test build
 ###############
 ##@ Development
 
-# This is to allow make to detect when other targes should be rerun (source changes)
+# This is to allow make to detect when other targets should be rerun (source changes)
 $(GO_FILES):
-	@stat -c "%y %n" "$@"
+	@ls -l "$@"
 
-.PHONY: $(EXECUTABLE)
+.PHONY: build
 build: $(ARTIFACT) ## Build binary
 $(ARTIFACT): $(GO_FILES)
 	@$(MAKE) --no-print-directory log-build
@@ -41,14 +37,18 @@ container: ## Build container using docker
 	@$(MAKE) --no-print-directory log-$@
 	@docker build -t gadget:local .
 
-.PHONY: lint ## Lint the project
-lint:
+.PHONY: fmt
+fmt: ## Check the project follows idiomatic formatting
+	@$(MAKE) --no-print-directory	log-$@
+	@golangci-lint fmt --diff
+
+.PHONY: lint
+lint: fmt ## Lint the project
 	@$(MAKE) --no-print-directory log-$@
-	@golangci-lint run ./...
+	@golangci-lint run
 
 .PHONY: test
-test: coverage.out ## Execute tests
-coverage.out: $(GO_FILES)
+test: $(GO_FILES) ## Execute tests
 	@$(MAKE) --no-print-directory log-$@
 	$(GO) test -coverprofile=coverage.out -covermode=atomic -v ./...
 
@@ -61,7 +61,7 @@ clean: ## Clean the workspace including modcache and dist/
 .PHONY: tools
 tools: ## Install tools needed for development
 	@$(MAKE) --no-print-directory log-$@
-	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
+	@$(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
 
 ###############
 ##@ Database


### PR DESCRIPTION
## Summary

- Remove broken build-time version injection (`COMMIT_HASH`, `GITVERSION`, `GOLDFLAGS`, ldflags) — the conf package never existed and this isn't a distributable binary
- Fix macOS compatibility (`stat -c` → `ls -l`), use `$(GO)` variable consistently, fix `.PHONY` target, exclude vendor from `GO_FILES`, simplify test target
- Use static dev DB credentials instead of random passwords
- Add `goimports` formatter with new `make fmt` target
- Enable `errcheck` and `zerologlint` linters

## Related issues

- Closes #96
- Related: #97, #99, #100

## Test plan

- [x] `make lint` runs successfully (will surface new errcheck/zerologlint findings)
- [x] `make fmt` detects formatting issues
- [x] `make test` passes
- [x] `make build` produces binary without ldflags errors