### PR TITLE
Enable gosec linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
   default: none
   enable:
     - errcheck
+    - gosec
     - govet
     - ineffassign
     - staticcheck


### PR DESCRIPTION
## Summary

- Enable `gosec` in the golangci-lint configuration to surface security-related findings

## Related issues

- #98 — G114: `http.ListenAndServe` without timeouts
- #101 — G404: weak RNG in user_info plugin

## Test plan

- [x] `make lint` surfaces the expected gosec findings
- [x] No false positives beyond the known issues