### PR TITLE
Handle unchecked errors in production and test code

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -66,7 +66,10 @@ func requestLog(code int, r http.Request, denied bool, start time.Time, logger z
 
 func generateRequestID() string {
 	b := make([]byte, 8)
-	rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		log.Error().Err(err).Msg("Failed to generate random request ID")
+		return fmt.Sprintf("%x", time.Now().UnixNano())
+	}
 	return hex.EncodeToString(b)
 }
 
@@ -205,7 +208,9 @@ func Setup() (*Gadget, error) {
 	log.Debug().Str("version", version).Msg("Connected to DB")
 
 	gadget.Router.DbConnection = db
-	gadget.Router.SetupDb()
+	if err := gadget.Router.SetupDb(); err != nil {
+		return &gadget, fmt.Errorf("setup database: %w", err)
+	}
 
 	var globalAdmins models.Group
 	var globalAdminUsers []models.User
@@ -217,7 +222,9 @@ func Setup() (*Gadget, error) {
 	}
 
 	db.Where(models.Group{Name: "globalAdmins"}).FirstOrCreate(&globalAdmins)
-	db.Model(&globalAdmins).Association("Members").Replace(globalAdminUsers)
+	if err := db.Model(&globalAdmins).Association("Members").Replace(globalAdminUsers); err != nil {
+		return &gadget, fmt.Errorf("replace global admin members: %w", err)
+	}
 
 	return &gadget, nil
 }
@@ -272,7 +279,9 @@ func (gadget Gadget) Handler() http.Handler {
 				return
 			}
 			w.Header().Set("Content-Type", "text")
-			w.Write([]byte(res.Challenge))
+			if _, err := w.Write([]byte(res.Challenge)); err != nil {
+				logger.Error().Err(err).Msg("Failed to write URL verification challenge response")
+			}
 		}
 
 		if eventsAPIEvent.Type == slackevents.CallbackEvent {
@@ -359,7 +368,9 @@ func (gadget Gadget) Handler() http.Handler {
 		route, exists := gadget.Router.FindSlashCommandRouteByCommand(cmd.Command)
 		if !exists {
 			w.Header().Set("Content-Type", "application/json")
-			w.Write([]byte(`{"response_type":"ephemeral","text":"Unknown command."}`))
+			if _, err := w.Write([]byte(`{"response_type":"ephemeral","text":"Unknown command."}`)); err != nil {
+				logger.Error().Err(err).Msg("Failed to write unknown command response")
+			}
 			return
 		}
 
@@ -392,7 +403,9 @@ func (gadget Gadget) Handler() http.Handler {
 				return
 			}
 			w.Header().Set("Content-Type", "application/json")
-			w.Write(resp)
+			if _, err := w.Write(resp); err != nil {
+				logger.Error().Err(err).Msg("Failed to write immediate response")
+			}
 		}
 		safeGo(route.Name, logger, func() { route.Execute(gadget.Router, *gadget.Client, cmd) })
 		if route.ImmediateResponse == "" {

--- a/main.go
+++ b/main.go
@@ -16,5 +16,7 @@ func main() {
 
 	// This launches your bot
 
-	myBot.Run()
+	if err := myBot.Run(); err != nil {
+		log.Fatal().Err(err).Msg("Bot stopped")
+	}
 }

--- a/models/user_test.go
+++ b/models/user_test.go
@@ -14,7 +14,7 @@ func TestUserInfo_ReturnsNilOnAPIError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"ok":false,"error":"user_not_found"}`))
+		_, _ = w.Write([]byte(`{"ok":false,"error":"user_not_found"}`)) //nolint:errcheck // test HTTP response on loopback
 	}))
 	defer server.Close()
 
@@ -30,7 +30,7 @@ func TestUserInfo_ReturnsUserOnSuccess(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{
+		_, _ = w.Write([]byte(`{
 			"ok": true,
 			"user": {
 				"id": "U123",
@@ -42,7 +42,7 @@ func TestUserInfo_ReturnsUserOnSuccess(t *testing.T) {
 					"email": "test@example.com"
 				}
 			}
-		}`))
+		}`)) //nolint:errcheck // test HTTP response on loopback
 	}))
 	defer server.Close()
 

--- a/plugins/fallback/fallback_test.go
+++ b/plugins/fallback/fallback_test.go
@@ -27,14 +27,16 @@ func TestFallbackPlugin_PostsMessage(t *testing.T) {
 	var postedMessage string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/chat.postMessage" {
-			r.ParseForm()
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm failed: %v", err)
+			}
 			postedMessage = r.FormValue("text")
 			w.Header().Set("Content-Type", "application/json")
-			w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1234567890.123456"}`))
+			_, _ = w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1234567890.123456"}`)) //nolint:errcheck // test HTTP response on loopback
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"ok":true}`))
+		_, _ = w.Write([]byte(`{"ok":true}`)) //nolint:errcheck // test HTTP response on loopback
 	}))
 	defer server.Close()
 

--- a/plugins/groups/group_management.go
+++ b/plugins/groups/group_management.go
@@ -94,7 +94,13 @@ func addUserToGroup() *router.MentionRoute {
 
 		router.DbConnection.Where(models.Group{Name: groupName}).FirstOrCreate(&foundGroup)
 		router.DbConnection.Where(models.User{Uuid: userName}).FirstOrCreate(&foundUser)
-		router.DbConnection.Model(&foundGroup).Association("Members").Append(&foundUser)
+		if err := router.DbConnection.Model(&foundGroup).Association("Members").Append(&foundUser); err != nil {
+			helpers.PostMessage(api, ev.Channel, "groups.addUserToGroup",
+				slack.MsgOptionText(fmt.Sprintf("Failed to add <@%s> to %s: %s", userName, groupName, err), false),
+				helpers.ThreadReplyOption(ev.ThreadTimeStamp),
+			)
+			return
+		}
 
 		helpers.PostMessage(api, ev.Channel, "groups.addUserToGroup",
 			slack.MsgOptionText(fmt.Sprintf("I successfully added <@%s> to %s!", userName, groupName), false),
@@ -138,8 +144,11 @@ func removeUserFromGroup() *router.MentionRoute {
 			}
 
 			if wasMember {
-				router.DbConnection.Model(&foundGroup).Association("Members").Replace(newMembersList)
-				response = fmt.Sprintf("<@%s> is no longer a member of %s!", userName, groupName)
+				if err := router.DbConnection.Model(&foundGroup).Association("Members").Replace(newMembersList); err != nil {
+					response = fmt.Sprintf("Failed to remove <@%s> from %s: %s", userName, groupName, err)
+				} else {
+					response = fmt.Sprintf("<@%s> is no longer a member of %s!", userName, groupName)
+				}
 			} else {
 				response = fmt.Sprintf("It doesn't look like <@%s> is a member of %s.", userName, groupName)
 			}

--- a/plugins/groups/group_management_test.go
+++ b/plugins/groups/group_management_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/slackevents"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 	gormlogger "gorm.io/gorm/logger"
@@ -98,16 +99,18 @@ func TestGetMyGroups_PostsGroupList(t *testing.T) {
 	db.Create(&user)
 	group := models.Group{Name: "deployers"}
 	db.Create(&group)
-	db.Model(&group).Association("Members").Append(&user)
+	require.NoError(t, db.Model(&group).Association("Members").Append(&user))
 
 	var messages []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path == "/chat.postMessage" {
-			r.ParseForm()
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm failed: %v", err)
+			}
 			messages = append(messages, r.FormValue("text"))
 		}
-		w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1234567890.123456"}`))
+		_, _ = w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1234567890.123456"}`)) //nolint:errcheck // test HTTP response on loopback
 	}))
 	defer server.Close()
 
@@ -137,10 +140,12 @@ func TestGetMyGroups_NoGroups(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path == "/chat.postMessage" {
-			r.ParseForm()
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm failed: %v", err)
+			}
 			messages = append(messages, r.FormValue("text"))
 		}
-		w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1234567890.123456"}`))
+		_, _ = w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1234567890.123456"}`)) //nolint:errcheck // test HTTP response on loopback
 	}))
 	defer server.Close()
 
@@ -168,13 +173,17 @@ func TestAddUserToGroup_AddsSuccessfully(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/reactions.add":
-			r.ParseForm()
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm failed: %v", err)
+			}
 			addedReaction = r.FormValue("name")
 		case "/chat.postMessage":
-			r.ParseForm()
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm failed: %v", err)
+			}
 			postedMessage = r.FormValue("text")
 		}
-		w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1234567890.123456"}`))
+		_, _ = w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1234567890.123456"}`)) //nolint:errcheck // test HTTP response on loopback
 	}))
 	defer server.Close()
 
@@ -211,16 +220,18 @@ func TestRemoveUserFromGroup_RemovesSuccessfully(t *testing.T) {
 	db.Create(&user)
 	group := models.Group{Name: "deployers"}
 	db.Create(&group)
-	db.Model(&group).Association("Members").Append(&user)
+	require.NoError(t, db.Model(&group).Association("Members").Append(&user))
 
 	var postedMessage string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path == "/chat.postMessage" {
-			r.ParseForm()
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm failed: %v", err)
+			}
 			postedMessage = r.FormValue("text")
 		}
-		w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1234567890.123456"}`))
+		_, _ = w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1234567890.123456"}`)) //nolint:errcheck // test HTTP response on loopback
 	}))
 	defer server.Close()
 
@@ -251,10 +262,12 @@ func TestRemoveUserFromGroup_NonexistentGroup(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path == "/chat.postMessage" {
-			r.ParseForm()
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm failed: %v", err)
+			}
 			postedMessage = r.FormValue("text")
 		}
-		w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1234567890.123456"}`))
+		_, _ = w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1234567890.123456"}`)) //nolint:errcheck // test HTTP response on loopback
 	}))
 	defer server.Close()
 
@@ -286,10 +299,12 @@ func TestGetAllGroups_PostsAllGroups(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path == "/chat.postMessage" {
-			r.ParseForm()
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm failed: %v", err)
+			}
 			messages = append(messages, r.FormValue("text"))
 		}
-		w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1234567890.123456"}`))
+		_, _ = w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1234567890.123456"}`)) //nolint:errcheck // test HTTP response on loopback
 	}))
 	defer server.Close()
 
@@ -318,16 +333,18 @@ func TestAddUserToGroup_UserAlreadyInGroup(t *testing.T) {
 	db.Create(&user)
 	group := models.Group{Name: "deployers"}
 	db.Create(&group)
-	db.Model(&group).Association("Members").Append(&user)
+	require.NoError(t, db.Model(&group).Association("Members").Append(&user))
 
 	var postedMessage string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path == "/chat.postMessage" {
-			r.ParseForm()
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm failed: %v", err)
+			}
 			postedMessage = r.FormValue("text")
 		}
-		w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1234567890.123456"}`))
+		_, _ = w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1234567890.123456"}`)) //nolint:errcheck // test HTTP response on loopback
 	}))
 	defer server.Close()
 
@@ -364,10 +381,12 @@ func TestRemoveUserFromGroup_UserNotAMember(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path == "/chat.postMessage" {
-			r.ParseForm()
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm failed: %v", err)
+			}
 			postedMessage = r.FormValue("text")
 		}
-		w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1234567890.123456"}`))
+		_, _ = w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1234567890.123456"}`)) //nolint:errcheck // test HTTP response on loopback
 	}))
 	defer server.Close()
 

--- a/plugins/permission_denied/permission_denied_test.go
+++ b/plugins/permission_denied/permission_denied_test.go
@@ -54,15 +54,19 @@ func TestMentionPlugin_AddsReactionAndPostsMessage(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/reactions.add":
-			r.ParseForm()
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm failed: %v", err)
+			}
 			addedReaction = r.FormValue("name")
-			w.Write([]byte(`{"ok":true}`))
+			_, _ = w.Write([]byte(`{"ok":true}`)) //nolint:errcheck // test HTTP response on loopback
 		case "/chat.postMessage":
-			r.ParseForm()
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm failed: %v", err)
+			}
 			postedMessage = r.FormValue("text")
-			w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1234567890.123456"}`))
+			_, _ = w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1234567890.123456"}`)) //nolint:errcheck // test HTTP response on loopback
 		default:
-			w.Write([]byte(`{"ok":true}`))
+			_, _ = w.Write([]byte(`{"ok":true}`)) //nolint:errcheck // test HTTP response on loopback
 		}
 	}))
 	defer server.Close()
@@ -90,15 +94,19 @@ func TestChannelMessagePlugin_AddsReactionAndPostsMessage(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/reactions.add":
-			r.ParseForm()
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm failed: %v", err)
+			}
 			addedReaction = r.FormValue("name")
-			w.Write([]byte(`{"ok":true}`))
+			_, _ = w.Write([]byte(`{"ok":true}`)) //nolint:errcheck // test HTTP response on loopback
 		case "/chat.postMessage":
-			r.ParseForm()
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm failed: %v", err)
+			}
 			postedMessage = r.FormValue("text")
-			w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1234567890.123456"}`))
+			_, _ = w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1234567890.123456"}`)) //nolint:errcheck // test HTTP response on loopback
 		default:
-			w.Write([]byte(`{"ok":true}`))
+			_, _ = w.Write([]byte(`{"ok":true}`)) //nolint:errcheck // test HTTP response on loopback
 		}
 	}))
 	defer server.Close()

--- a/plugins/user_info/user_info_test.go
+++ b/plugins/user_info/user_info_test.go
@@ -61,7 +61,7 @@ func TestUserInfoPlugin_PostsUserDetails(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/users.info":
-			w.Write([]byte(`{
+			_, _ = w.Write([]byte(`{
 				"ok": true,
 				"user": {
 					"id": "u456",
@@ -71,13 +71,15 @@ func TestUserInfoPlugin_PostsUserDetails(t *testing.T) {
 					"locale": "en-US",
 					"profile": {"email": "test@example.com"}
 				}
-			}`))
+			}`)) //nolint:errcheck // test HTTP response on loopback
 		case "/chat.postMessage":
-			r.ParseForm()
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm failed: %v", err)
+			}
 			postedMessage = r.FormValue("text")
-			w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1234567890.123456"}`))
+			_, _ = w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1234567890.123456"}`)) //nolint:errcheck // test HTTP response on loopback
 		default:
-			w.Write([]byte(`{"ok":true}`))
+			_, _ = w.Write([]byte(`{"ok":true}`)) //nolint:errcheck // test HTTP response on loopback
 		}
 	}))
 	defer server.Close()
@@ -107,13 +109,15 @@ func TestUserInfoPlugin_UserNotFound(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/users.info":
-			w.Write([]byte(`{"ok":false,"error":"user_not_found"}`))
+			_, _ = w.Write([]byte(`{"ok":false,"error":"user_not_found"}`)) //nolint:errcheck // test HTTP response on loopback
 		case "/chat.postMessage":
-			r.ParseForm()
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm failed: %v", err)
+			}
 			postedMessage = r.FormValue("text")
-			w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1234567890.123456"}`))
+			_, _ = w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1234567890.123456"}`)) //nolint:errcheck // test HTTP response on loopback
 		default:
-			w.Write([]byte(`{"ok":true}`))
+			_, _ = w.Write([]byte(`{"ok":true}`)) //nolint:errcheck // test HTTP response on loopback
 		}
 	}))
 	defer server.Close()

--- a/router/router.go
+++ b/router/router.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 
 	"github.com/gadget-bot/gadget/models"
+	"github.com/rs/zerolog/log"
 
 	"gorm.io/gorm"
 )
@@ -102,10 +103,14 @@ func getBotUidFromBody(body []byte) (string, error) {
 }
 
 // SetupDb migrates the schemas
-func (router Router) SetupDb() {
-	// Migrate the schema
-	router.DbConnection.AutoMigrate(&models.Group{})
-	router.DbConnection.AutoMigrate(&models.User{})
+func (router Router) SetupDb() error {
+	if err := router.DbConnection.AutoMigrate(&models.Group{}); err != nil {
+		return fmt.Errorf("auto-migrate Group: %w", err)
+	}
+	if err := router.DbConnection.AutoMigrate(&models.User{}); err != nil {
+		return fmt.Errorf("auto-migrate User: %w", err)
+	}
+	return nil
 }
 
 // FindChannelMessageRouteByName looks up and return the ChannelMessageRoute by the provided Name field value
@@ -172,7 +177,10 @@ func (router Router) Can(u models.User, permissions []string) bool {
 	var userGroupNames []string
 	var userGroups []models.Group
 
-	router.DbConnection.Model(&u).Association("Groups").Find(&userGroups)
+	if err := router.DbConnection.Model(&u).Association("Groups").Find(&userGroups); err != nil {
+		log.Error().Err(err).Str("user", u.Uuid).Msg("Failed to load user groups for permission check")
+		return false
+	}
 
 	for _, userGroup := range userGroups {
 		groupName := userGroup.Name

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/slackevents"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 	gormlogger "gorm.io/gorm/logger"
@@ -331,7 +332,7 @@ func TestCan_GlobalAdminAllowed(t *testing.T) {
 	db.Create(&user)
 	group := models.Group{Name: "globalAdmins"}
 	db.Create(&group)
-	db.Model(&group).Association("Members").Append(&user)
+	require.NoError(t, db.Model(&group).Association("Members").Append(&user))
 
 	assert.True(t, r.Can(user, []string{"some_permission"}))
 }
@@ -367,7 +368,7 @@ func TestCan_UserInMatchingGroup(t *testing.T) {
 	db.Create(&user)
 	group := models.Group{Name: "deployers"}
 	db.Create(&group)
-	db.Model(&group).Association("Members").Append(&user)
+	require.NoError(t, db.Model(&group).Association("Members").Append(&user))
 
 	assert.True(t, r.Can(user, []string{"deployers"}))
 }
@@ -381,7 +382,7 @@ func TestCan_UserInNonMatchingGroup(t *testing.T) {
 	db.Create(&user)
 	group := models.Group{Name: "viewers"}
 	db.Create(&group)
-	db.Model(&group).Association("Members").Append(&user)
+	require.NoError(t, db.Model(&group).Association("Members").Append(&user))
 
 	assert.False(t, r.Can(user, []string{"deployers"}))
 }
@@ -397,8 +398,8 @@ func TestCan_UserInMultipleGroupsOneMatching(t *testing.T) {
 	deployers := models.Group{Name: "deployers"}
 	db.Create(&viewers)
 	db.Create(&deployers)
-	db.Model(&viewers).Association("Members").Append(&user)
-	db.Model(&deployers).Association("Members").Append(&user)
+	require.NoError(t, db.Model(&viewers).Association("Members").Append(&user))
+	require.NoError(t, db.Model(&deployers).Association("Members").Append(&user))
 
 	assert.True(t, r.Can(user, []string{"deployers"}))
 }


### PR DESCRIPTION
## Summary

- Check all error return values flagged by the `errcheck` linter across production code (`core/core.go`, `router/router.go`, `plugins/groups/group_management.go`, `main.go`) and test helpers (`models/user_test.go`, `plugins/fallback/fallback_test.go`, `plugins/groups/group_management_test.go`, `plugins/permission_denied/permission_denied_test.go`, `plugins/user_info/user_info_test.go`, `router/router_test.go`)
- Change `SetupDb()` to return `error` and propagate it through the `Setup()` call chain
- Add zerolog error logging for permission check failures and HTTP response write errors
- Wrap test `w.Write` calls with `_, _ =` and `r.ParseForm()` / `Association.Append()` calls with proper error handling

Closes #99
Closes #100

## Test plan

- [x] `make test` passes with all tests green
- [x] `make lint` shows zero `errcheck` findings (only pre-existing `gosec` G114 and G404 remain)
- [x] Verify no regressions in CI