### PR TITLE
Add channel helper functions

### DIFF
--- a/plugins/helpers/helpers.go
+++ b/plugins/helpers/helpers.go
@@ -1,6 +1,8 @@
 package helpers
 
 import (
+	"fmt"
+
 	"github.com/rs/zerolog/log"
 	"github.com/slack-go/slack"
 )
@@ -34,4 +36,64 @@ func AddReaction(api slack.Client, channel, plugin, reaction, timestamp string) 
 	if err := api.AddReaction(reaction, msgRef); err != nil {
 		log.Error().Err(err).Str("channel", channel).Str("plugin", plugin).Str("reaction", reaction).Msg("Failed to add reaction")
 	}
+}
+
+// FindChannelByName searches all conversations for a channel whose
+// NameNormalized matches name, handling pagination internally.
+// Returns the matching channel or an error if not found or if any API call fails.
+func FindChannelByName(api slack.Client, name string) (slack.Channel, error) {
+	params := &slack.GetConversationsParameters{}
+	for {
+		channels, cursor, err := api.GetConversations(params)
+		if err != nil {
+			return slack.Channel{}, fmt.Errorf("listing conversations: %w", err)
+		}
+		for _, ch := range channels {
+			if ch.NameNormalized == name {
+				return ch, nil
+			}
+		}
+		if cursor == "" {
+			break
+		}
+		params.Cursor = cursor
+	}
+	return slack.Channel{}, fmt.Errorf("channel not found: %s", name)
+}
+
+// GetJoinedChannels returns all conversations the bot is currently a member of.
+// Pagination is handled internally.
+func GetJoinedChannels(api slack.Client) ([]slack.Channel, error) {
+	var joined []slack.Channel
+	params := &slack.GetConversationsParameters{}
+	for {
+		channels, cursor, err := api.GetConversations(params)
+		if err != nil {
+			return nil, fmt.Errorf("listing conversations: %w", err)
+		}
+		for _, ch := range channels {
+			if ch.IsMember {
+				joined = append(joined, ch)
+			}
+		}
+		if cursor == "" {
+			break
+		}
+		params.Cursor = cursor
+	}
+	return joined, nil
+}
+
+// JoinChannelByName finds the channel with the given name and joins it.
+// Pagination is handled internally. Returns an error if the channel is not
+// found or if any API call fails.
+func JoinChannelByName(api slack.Client, name string) error {
+	ch, err := FindChannelByName(api, name)
+	if err != nil {
+		return err
+	}
+	if _, _, _, err = api.JoinConversation(ch.ID); err != nil {
+		return fmt.Errorf("joining channel %s: %w", name, err)
+	}
+	return nil
 }

--- a/plugins/helpers/helpers_test.go
+++ b/plugins/helpers/helpers_test.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"bytes"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/slack-go/slack"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestThreadReplyOption_NonEmpty(t *testing.T) {
@@ -110,4 +112,162 @@ func TestAddReaction_NoErrorOnSuccess(t *testing.T) {
 	AddReaction(*api, "C123", "test_plugin", "thumbsup", "1234567890.123456")
 
 	assert.Empty(t, buf.String())
+}
+
+// newConversationListServer returns a test server that serves paginated
+// conversations.list responses. Each call to pages consumes the next page.
+func newConversationListServer(t *testing.T, pages []string) slack.Client {
+	t.Helper()
+	call := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if call < len(pages) {
+			_, _ = w.Write([]byte(pages[call]))
+		} else {
+			_, _ = w.Write([]byte(`{"ok":true,"channels":[],"response_metadata":{"next_cursor":""}}`))
+		}
+		call++
+	}))
+	t.Cleanup(ts.Close)
+	api := slack.New("xoxb-fake-token", slack.OptionAPIURL(ts.URL+"/"))
+	return *api
+}
+
+// newMultiHandlerServer returns a test server that routes requests by path.
+func newMultiHandlerServer(t *testing.T, handlers map[string]http.HandlerFunc) slack.Client {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if h, ok := handlers[r.URL.Path]; ok {
+			h(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":false,"error":"unexpected_path"}`))
+	}))
+	t.Cleanup(ts.Close)
+	api := slack.New("xoxb-fake-token", slack.OptionAPIURL(ts.URL+"/"))
+	return *api
+}
+
+func channelListJSONWithMembership(id, name string, isMember bool, cursor string) string {
+	member := "false"
+	if isMember {
+		member = "true"
+	}
+	return fmt.Sprintf(
+		`{"ok":true,"channels":[{"id":%q,"name":%q,"name_normalized":%q,"is_member":%s}],"response_metadata":{"next_cursor":%q}}`,
+		id, name, name, member, cursor,
+	)
+}
+
+func channelListJSON(id, name, cursor string) string {
+	nextCursor := ""
+	if cursor != "" {
+		nextCursor = cursor
+	}
+	return fmt.Sprintf(
+		`{"ok":true,"channels":[{"id":%q,"name":%q,"name_normalized":%q}],"response_metadata":{"next_cursor":%q}}`,
+		id, name, name, nextCursor,
+	)
+}
+
+func emptyChannelListJSON() string {
+	return `{"ok":true,"channels":[],"response_metadata":{"next_cursor":""}}`
+}
+
+func TestGetJoinedChannels_ReturnsMemberChannels(t *testing.T) {
+	// Two pages: first has one member and one non-member, second has one member.
+	page1 := `{"ok":true,"channels":[{"id":"C001","name":"general","name_normalized":"general","is_member":true},{"id":"C002","name":"random","name_normalized":"random","is_member":false}],"response_metadata":{"next_cursor":"cursor-page2"}}`
+	page2 := channelListJSONWithMembership("C003", "spam-feed", true, "")
+	api := newConversationListServer(t, []string{page1, page2})
+	channels, err := GetJoinedChannels(api)
+	require.NoError(t, err)
+	require.Len(t, channels, 2)
+	assert.Equal(t, "C001", channels[0].ID)
+	assert.Equal(t, "C003", channels[1].ID)
+}
+
+func TestGetJoinedChannels_EmptyWhenNoneJoined(t *testing.T) {
+	api := newConversationListServer(t, []string{emptyChannelListJSON()})
+	channels, err := GetJoinedChannels(api)
+	require.NoError(t, err)
+	assert.Empty(t, channels)
+}
+
+func TestGetJoinedChannels_APIError(t *testing.T) {
+	api := newErrorAPI(t)
+	_, err := GetJoinedChannels(api)
+	assert.ErrorContains(t, err, "listing conversations")
+}
+
+func TestFindChannelByName_Found(t *testing.T) {
+	api := newConversationListServer(t, []string{
+		channelListJSON("C001", "spam-feed", ""),
+	})
+	ch, err := FindChannelByName(api, "spam-feed")
+	require.NoError(t, err)
+	assert.Equal(t, "C001", ch.ID)
+	assert.Equal(t, "spam-feed", ch.NameNormalized)
+}
+
+func TestFindChannelByName_FoundAfterPagination(t *testing.T) {
+	api := newConversationListServer(t, []string{
+		channelListJSON("C001", "general", "cursor-page2"),
+		channelListJSON("C002", "spam-feed", ""),
+	})
+	ch, err := FindChannelByName(api, "spam-feed")
+	require.NoError(t, err)
+	assert.Equal(t, "C002", ch.ID)
+}
+
+func TestFindChannelByName_NotFound(t *testing.T) {
+	api := newConversationListServer(t, []string{
+		channelListJSON("C001", "general", ""),
+	})
+	_, err := FindChannelByName(api, "spam-feed")
+	assert.ErrorContains(t, err, "channel not found: spam-feed")
+}
+
+func TestFindChannelByName_APIError(t *testing.T) {
+	api := newErrorAPI(t)
+	_, err := FindChannelByName(api, "spam-feed")
+	assert.ErrorContains(t, err, "listing conversations")
+}
+
+func TestJoinChannelByName_Success(t *testing.T) {
+	api := newMultiHandlerServer(t, map[string]http.HandlerFunc{
+		"/conversations.list": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(channelListJSON("C001", "spam-feed", "")))
+		},
+		"/conversations.join": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true,"channel":{"id":"C001","name":"spam-feed"}}`))
+		},
+	})
+	err := JoinChannelByName(api, "spam-feed")
+	assert.NoError(t, err)
+}
+
+func TestJoinChannelByName_ChannelNotFound(t *testing.T) {
+	api := newConversationListServer(t, []string{emptyChannelListJSON()})
+	err := JoinChannelByName(api, "spam-feed")
+	assert.ErrorContains(t, err, "channel not found: spam-feed")
+}
+
+func TestJoinChannelByName_JoinError(t *testing.T) {
+	api := newMultiHandlerServer(t, map[string]http.HandlerFunc{
+		"/conversations.list": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(channelListJSON("C001", "spam-feed", "")))
+		},
+		"/conversations.join": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":false,"error":"cant_join_channel"}`))
+		},
+	})
+	err := JoinChannelByName(api, "spam-feed")
+	assert.ErrorContains(t, err, "joining channel spam-feed")
 }


### PR DESCRIPTION
## Summary

- Adds `FindChannelByName(api, name)` — paginates `conversations.list` and returns the matching `slack.Channel` by `NameNormalized`
- Adds `JoinChannelByName(api, name)` — wraps `FindChannelByName` + `JoinConversation`, eliminating ~50 lines of boilerplate per channel (e.g. Penny's `joinSpamFeedChannel`)
- Adds `GetJoinedChannels(api)` — returns all channels the bot is currently a member of by filtering on `Channel.IsMember`, suitable for a future read-only web UI

All three functions handle pagination internally. `GetJoinedChannels` reflects true Slack membership state (including channels joined via UI invite), not local registry state.

Closes #79.

## Test plan

- [x] `TestFindChannelByName_Found` — match on first page
- [x] `TestFindChannelByName_FoundAfterPagination` — match on second page
- [x] `TestFindChannelByName_NotFound` — returns descriptive error
- [x] `TestFindChannelByName_APIError` — wraps API error
- [x] `TestJoinChannelByName_Success` — finds and joins
- [x] `TestJoinChannelByName_ChannelNotFound` — propagates not-found error
- [x] `TestJoinChannelByName_JoinError` — wraps join API error
- [x] `TestGetJoinedChannels_ReturnsMemberChannels` — multi-page, filters non-members
- [x] `TestGetJoinedChannels_EmptyWhenNoneJoined` — returns empty slice, no error
- [x] `TestGetJoinedChannels_APIError` — wraps API error
- [x] `make lint` passes with 0 issues
- [x] `make test` passes with 100% coverage on `plugins/helpers`

🤖 Generated with [Claude Code](https://claude.com/claude-code)