### PR TITLE
Include private channels in conversations.list for channel helpers

### DIFF
--- a/plugins/helpers/helpers.go
+++ b/plugins/helpers/helpers.go
@@ -38,11 +38,14 @@ func AddReaction(api slack.Client, channel, plugin, reaction, timestamp string) 
 	}
 }
 
+// channelTypes lists the conversation types queried by channel helpers.
+var channelTypes = []string{"public_channel", "private_channel"}
+
 // FindChannelByName searches all conversations for a channel whose
 // NameNormalized matches name, handling pagination internally.
 // Returns the matching channel or an error if not found or if any API call fails.
 func FindChannelByName(api slack.Client, name string) (slack.Channel, error) {
-	params := &slack.GetConversationsParameters{}
+	params := &slack.GetConversationsParameters{Types: channelTypes}
 	for {
 		channels, cursor, err := api.GetConversations(params)
 		if err != nil {
@@ -65,7 +68,7 @@ func FindChannelByName(api slack.Client, name string) (slack.Channel, error) {
 // Pagination is handled internally.
 func GetJoinedChannels(api slack.Client) ([]slack.Channel, error) {
 	var joined []slack.Channel
-	params := &slack.GetConversationsParameters{}
+	params := &slack.GetConversationsParameters{Types: channelTypes}
 	for {
 		channels, cursor, err := api.GetConversations(params)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Pass `types=public_channel,private_channel` to `conversations.list` in `FindChannelByName` and `GetJoinedChannels`
- Previously relied on Slack's default (`public_channel` only), silently excluding private channels

## Test plan
- [x] `TestFindChannelByName_FindsPrivateChannel` — resolves a private channel
- [x] `TestGetJoinedChannels_IncludesPrivateChannels` — returns both public and private joined channels
- [x] `make test` and `make lint` pass

Closes #114