### PR TITLE
fix(core): add DBPort field to Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ export SLACK_SIGNING_SECRET="a...a"
 # DB Connection details
 export GADGET_DB_USER="gadgetuser"
 export GADGET_DB_PASS="secretpassword"
-export GADGET_DB_HOST="127.0.0.1:3306"
+export GADGET_DB_HOST="127.0.0.1"
+export GADGET_DB_PORT="3306" # optional; defaults to 3306
 export GADGET_DB_NAME="gadget_dev"
 # The port Gadget's webhook server listens on
 export GADGET_LISTEN_PORT="3000"

--- a/core/core.go
+++ b/core/core.go
@@ -40,6 +40,7 @@ type Config struct {
 	DBPass            string
 	DBHost            string
 	DBName            string
+	DBPort            string // optional; defaults to "3306" if empty
 	ListenPort        string
 	GlobalAdmins      []string
 	DBConnMaxLifetime time.Duration // max lifetime of a DB connection; 0 uses default (5m)
@@ -56,6 +57,7 @@ func ConfigFromEnv() Config {
 		DBPass:            os.Getenv("GADGET_DB_PASS"),
 		DBHost:            os.Getenv("GADGET_DB_HOST"),
 		DBName:            os.Getenv("GADGET_DB_NAME"),
+		DBPort:            os.Getenv("GADGET_DB_PORT"),
 		ListenPort:        os.Getenv("GADGET_LISTEN_PORT"),
 		GlobalAdmins:      globalAdminsFromString(os.Getenv("GADGET_GLOBAL_ADMINS")),
 		DBConnMaxLifetime: parseDurationEnv("GADGET_DB_CONN_MAX_LIFETIME"),
@@ -263,7 +265,11 @@ func SetupWithConfig(cfg Config) (*Gadget, error) {
 	default:
 		gormLogLevel = gormlogger.Silent
 	}
-	dsn := fmt.Sprintf("%s:%s@tcp(%s)/%s?charset=utf8mb4&parseTime=True", cfg.DBUser, cfg.DBPass, cfg.DBHost, cfg.DBName)
+	dbPort := cfg.DBPort
+	if dbPort == "" {
+		dbPort = "3306"
+	}
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=True", cfg.DBUser, cfg.DBPass, cfg.DBHost, dbPort, cfg.DBName)
 	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{
 		Logger: gormlogger.Default.LogMode(gormLogLevel),
 	})

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -45,6 +45,14 @@ func TestConfigFromEnv_ReadsSlackUserToken(t *testing.T) {
 	assert.Equal(t, "xoxp-from-env", cfg.SlackUserToken)
 }
 
+func TestConfigFromEnv_ReadsDBPort(t *testing.T) {
+	t.Setenv("GADGET_DB_PORT", "3307")
+
+	cfg := ConfigFromEnv()
+
+	assert.Equal(t, "3307", cfg.DBPort)
+}
+
 func TestGlobalAdminsFromString(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

- Adds `DBPort` field to `gadget.Config` struct for configuring non-standard database ports
- Adds `GADGET_DB_PORT` environment variable support in `ConfigFromEnv()`
- Defaults to `"3306"` when `DBPort` is empty (mirrors previous implicit behavior)
- Fixes a silent regression for users upgrading from v0.6.x who use non-default DB ports
- Updates README example to split `GADGET_DB_HOST` and `GADGET_DB_PORT` correctly

## Related

Closes #132

## Test plan

- [x] `make test` — all tests pass
- [x] Verify `DBPort` is read from env in new `TestConfigFromEnv_ReadsDBPort`
- [x] Verify DSN includes port with default of "3306" when unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)