### PR TITLE
docs(helpers): document decision to exclude mpim/im from channelTypes

### DIFF
--- a/plugins/helpers/helpers.go
+++ b/plugins/helpers/helpers.go
@@ -39,6 +39,24 @@ func AddReaction(api slack.Client, channel, plugin, reaction, timestamp string) 
 }
 
 // channelTypes lists the conversation types queried by channel helpers.
+//
+// Only public and private channels are included here. Slack's
+// conversations.list API also accepts "mpim" (multi-person direct messages)
+// and "im" (1:1 direct messages), but those are intentionally excluded:
+//
+//   - The channel helpers (FindChannelByName, GetJoinedChannels) are designed
+//     for addressing named channels, not DM threads. DMs and group DMs do not
+//     have stable, human-readable names the way channels do, so including them
+//     would produce confusing matches and inflate the result set.
+//   - Most bot use cases route on channel names and mentions, not on DM
+//     conversations. Plugins that need DM context should use the Slack Events
+//     API directly rather than the conversations.list helpers.
+//   - Requesting fewer conversation types keeps pagination faster and reduces
+//     the chance of hitting Slack rate limits on large workspaces.
+//
+// If a future plugin needs DM resolution, introduce a separate, dedicated
+// helper with its own type filter rather than widening this list, so existing
+// callers continue to see only channels. See issue #128.
 var channelTypes = []string{"public_channel", "private_channel"}
 
 // FindChannelByName searches all conversations for a channel whose

--- a/plugins/helpers/helpers_test.go
+++ b/plugins/helpers/helpers_test.go
@@ -137,8 +137,8 @@ func newConversationListServer(t *testing.T, pages []string) slack.Client {
 }
 
 // assertConversationListTypes verifies that a conversations.list request
-// includes both public_channel and private_channel in the types parameter
-// and sets exclude_archived=true.
+// includes both public_channel and private_channel in the types parameter,
+// sets exclude_archived=true, and intentionally excludes mpim/im (see issue #128).
 func assertConversationListTypes(t *testing.T, r *http.Request) {
 	t.Helper()
 	if err := r.ParseForm(); err != nil {
@@ -147,6 +147,8 @@ func assertConversationListTypes(t *testing.T, r *http.Request) {
 	types := r.FormValue("types")
 	assert.Contains(t, types, "public_channel", "conversations.list must request public_channel")
 	assert.Contains(t, types, "private_channel", "conversations.list must request private_channel")
+	assert.NotContains(t, types, "mpim", "conversations.list must not request mpim (see issue #128)")
+	assert.NotContains(t, types, "im", "conversations.list must not request im (see issue #128)")
 	assert.Equal(t, "true", r.FormValue("exclude_archived"), "conversations.list must exclude archived channels")
 }
 


### PR DESCRIPTION
## Summary

Resolves #128.

Issue #128 asked for a decision on whether to include `mpim` (multi-person DMs) and `im` (1:1 DMs) in the `channelTypes` variable used by `FindChannelByName` and `GetJoinedChannels`.

## Decision

**Exclude `mpim` and `im` intentionally.** The channel helpers are designed for addressing named channels, not DM threads. This change documents the rationale and locks it in with a test assertion.

## Rationale

- **Naming semantics:** DMs and group DMs do not have stable, human-readable names the way channels do. Including them would produce confusing matches and inflate the result set from `FindChannelByName`.
- **Use-case fit:** Most bot use cases route on channel names and mentions, not on DM conversations. Plugins that need DM context should use the Slack Events API directly rather than the `conversations.list` helpers.
- **Performance:** Requesting fewer conversation types keeps pagination faster and reduces the chance of hitting Slack rate limits on large workspaces.
- **Forward path:** If a future plugin needs DM resolution, a separate dedicated helper with its own type filter should be introduced rather than widening this list, so existing callers continue to see only channels.

## Changes

- `plugins/helpers/helpers.go`: Added a detailed comment to `channelTypes` documenting the intentional exclusion of `mpim`/`im` and the rationale, with a reference to issue #128 and guidance for future DM-resolution needs.
- `plugins/helpers/helpers_test.go`: Strengthened `assertConversationListTypes` to assert that `mpim` and `im` are **not** present in the `types` parameter, locking the decision in against silent regression. This runs on every `conversations.list` call made by the existing test suite.

## Verification

- `go test ./plugins/helpers/ -v -count=1` — all 14 tests pass
- `go test ./...` — all packages pass
- `gofmt -l .` — clean
- `go vet ./plugins/helpers/` — clean
- `git status` — only the two intended files modified, no temp files

## Notes

This is a documentation + test-hardening change. No runtime behavior changes. The existing tests already asserted that `public_channel` and `private_channel` are present; they now also assert that `mpim` and `im` are absent.

**Hermes nightly maintenance run — left open for review. Not merging.**