### PR TITLE
fix(build): Dockerfile dependency caching, CA certs, and CGO fix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.github
+dist
+coverage.out
+*.md
+.claude
+.tool-versions

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,20 @@
-FROM golang:alpine AS builder
+FROM golang:1.25-alpine AS builder
 
-COPY . /usr/local/gadget/
+WORKDIR /build
 
-WORKDIR /usr/local/gadget/
+# Cache dependencies before copying source
+COPY go.mod go.sum ./
+RUN go mod download
 
-RUN go clean && \
-    go get && \
-    go build -ldflags "-s -w" -o dist/gadget
+COPY . .
+RUN CGO_ENABLED=0 go build -ldflags "-s -w" -o dist/gadget
 
-FROM alpine
+FROM alpine:3.20
 
-COPY --from=builder /usr/local/gadget/dist/gadget /usr/local/bin/gadget
+RUN apk add --no-cache ca-certificates && \
+    adduser -D -s /bin/nologin -H -u 1000 gadget
 
-RUN adduser -D -s /bin/nologin -H -u 1000 gadget
+COPY --from=builder /build/dist/gadget /usr/local/bin/gadget
 
 USER gadget
 


### PR DESCRIPTION
Fixes #139

## Changes

- **Adds a dependency caching layer** — copies `go.mod`/`go.sum` and runs `go mod download` before copying source, so dependencies are cached and only re-downloaded when they change
- **Removes deprecated `go get`** from the build step (no longer needed with modules and Go 1.18+)
- **Sets `CGO_ENABLED=0`** in the Dockerfile to match the Makefile's static binary build
- **Installs `ca-certificates`** in the final Alpine image (required for Slack API HTTPS calls)
- **Adds a `.dockerignore`** to exclude `.git`, `dist`, coverage output, docs, and IDE configs from the build context
- **Pins the Go builder** to `golang:1.25-alpine` and the runtime to `alpine:3.20` for reproducible builds

## Notes

- No Go source files were modified
- `go build ./...`, `go test ./...`, and `gofmt -l .` all pass