### PR TITLE
refactor: replace reflect in userFromInnerEvent

### DIFF
--- a/core/core_test.go
+++ b/core/core_test.go
@@ -76,7 +76,7 @@ func TestGlobalAdminsFromString(t *testing.T) {
 	}
 }
 
-func TestUnsupportedEventType(t *testing.T) {
+func TestUserFromInnerEvent(t *testing.T) {
 	tests := []struct {
 		name     string
 		event    *slackevents.EventsAPIInnerEvent
@@ -131,10 +131,8 @@ func TestUnsupportedEventType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := userFromInnerEvent(tt.event)
-			if got != tt.expected {
-				t.Errorf("got: %q, want: %q", got, tt.expected)
-			}
+			result := userFromInnerEvent(tt.event)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"testing"
 
+	"github.com/slack-go/slack/slackevents"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -71,6 +72,69 @@ func TestGlobalAdminsFromString(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := globalAdminsFromString(tt.input)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestUnsupportedEventType(t *testing.T) {
+	tests := []struct {
+		name     string
+		event    *slackevents.EventsAPIInnerEvent
+		expected string
+	}{
+		{
+			name: "AppMentionEvent",
+			event: &slackevents.EventsAPIInnerEvent{
+				Data: &slackevents.AppMentionEvent{
+					User: "U123",
+				},
+			},
+			expected: "U123",
+		},
+		{
+			name: "MessageEvent",
+			event: &slackevents.EventsAPIInnerEvent{
+				Data: &slackevents.MessageEvent{
+					User: "U456",
+				},
+			},
+			expected: "U456",
+		},
+		{
+			name: "ChannelCreatedEvent",
+			event: &slackevents.EventsAPIInnerEvent{
+				Data: &slackevents.ChannelCreatedEvent{
+					Channel: slackevents.ChannelCreatedInfo{
+						Name: "U789",
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "FileDeletedEvent",
+			event: &slackevents.EventsAPIInnerEvent{
+				Data: slackevents.FileDeletedEvent{
+					FileID: "F123",
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "UnsupportedEvent",
+			event: &slackevents.EventsAPIInnerEvent{
+				Data: struct{}{},
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := userFromInnerEvent(tt.event)
+			if got != tt.expected {
+				t.Errorf("got: %q, want: %q", got, tt.expected)
+			}
 		})
 	}
 }

--- a/core/events_helper.go
+++ b/core/events_helper.go
@@ -1,11 +1,16 @@
 package core
 
 import (
-	"reflect"
-
 	"github.com/slack-go/slack/slackevents"
 )
 
 func userFromInnerEvent(event *slackevents.EventsAPIInnerEvent) string {
-	return reflect.ValueOf(event.Data).Elem().FieldByName("User").String()
+	switch ev := event.Data.(type) {
+	case *slackevents.AppMentionEvent:
+		return ev.User
+	case *slackevents.MessageEvent:
+		return ev.User
+	default:
+		return ""
+	}
 }


### PR DESCRIPTION
## Changes

- Replace reflection with explicit type switch in `core/events_helper.go`
- Remove the reflect import
- Add a test cases for unsupported event types returning empty string

Fixes #140 