### PR TITLE
ci: add Dependabot config for gomod and github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - enhancement
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 2
+    labels:
+      - enhancement


### PR DESCRIPTION
Fixes #138

## Changes

- Adds `.github/dependabot.yml` with weekly update schedules for:
  - **Go modules** (gomod ecosystem, 5 open PRs limit)
  - **GitHub Actions versions** (github-actions ecosystem, 2 open PRs limit)
- Both ecosystems are labeled with `enhancement` for consistent triage

## Notes

- No Go source files were modified
- This enables automated dependency update PRs, which will help address the outdated dependencies tracked in #137
- Dependabot alerts (security vulnerability scanning) still need to be enabled separately in the repository settings by Jonathan, as that requires admin access