### PR TITLE
fix(core): check error from db.Raw VERSION() query

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -296,8 +296,11 @@ func SetupWithConfig(cfg Config) (*Gadget, error) {
 	log.Debug().Int("maxOpenConns", 10).Int("maxIdleConns", 5).Msg("DB connection pool configured")
 
 	var version string
-	db.Raw("SELECT VERSION() as version").Scan(&version)
-	log.Debug().Str("version", version).Msg("Connected to DB")
+	if err := db.Raw("SELECT VERSION() as version").Scan(&version).Error; err != nil {
+		log.Warn().Err(err).Msg("Failed to query DB version")
+	} else {
+		log.Debug().Str("version", version).Msg("Connected to DB")
+	}
 
 	gadget.Router.DbConnection = db
 	if err := gadget.Router.SetupDb(); err != nil {


### PR DESCRIPTION
Fixes #147

## Changes

- The `db.Raw("SELECT VERSION() as version").Scan(&version)` call in `core/core.go` previously ignored its error return
- If the query failed, `version` remained empty and the log message said `Connected to DB` with an empty version string
- Now checks `.Error` and logs a warning on failure, only logging the debug message on success

## Verification

- ✅ `go test ./...` — all packages pass
- ✅ `gofmt -l .` — clean
- ✅ `go vet ./...` — clean
- ✅ Minimal change (5 insertions, 2 deletions), no logic changes outside the error check