### PR TITLE
feat(core): add graceful HTTP shutdown on SIGTERM/SIGINT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Routes are added via `Router.AddMentionRoute()` / `Router.AddMentionRoutes()` an
 
 ### Configuration
 
-Environment variables: `SLACK_OAUTH_TOKEN`, `SLACK_SIGNING_SECRET`, `GADGET_GLOBAL_ADMINS` (comma-separated user IDs), `GADGET_DB_USER`, `GADGET_DB_PASS`, `GADGET_DB_HOST`, `GADGET_DB_NAME`, `GADGET_LISTEN_PORT` (default 3000), `GADGET_LOG_LEVEL` (default `info`; valid values: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic`).
+Environment variables: `SLACK_OAUTH_TOKEN`, `SLACK_SIGNING_SECRET`, `GADGET_GLOBAL_ADMINS` (comma-separated user IDs), `GADGET_DB_USER`, `GADGET_DB_PASS`, `GADGET_DB_HOST`, `GADGET_DB_NAME`, `GADGET_LISTEN_PORT` (default 3000), `GADGET_LOG_LEVEL` (default `info`; valid values: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic`), `GADGET_SHUTDOWN_TIMEOUT` (default `10s`; max time to drain in-flight requests on SIGINT/SIGTERM before forcing shutdown).
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ export GADGET_DB_PORT="3306" # optional; defaults to 3306
 export GADGET_DB_NAME="gadget_dev"
 # The port Gadget's webhook server listens on
 export GADGET_LISTEN_PORT="3000"
+# Optional; max time to drain in-flight requests on SIGINT/SIGTERM before forcing shutdown (default 10s)
+export GADGET_SHUTDOWN_TIMEOUT="10s"
 
 go run .
 ```

--- a/core/core.go
+++ b/core/core.go
@@ -2,16 +2,21 @@ package core
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
+	"os/signal"
 	"runtime/debug"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/gadget-bot/gadget/manifest"
@@ -45,6 +50,7 @@ type Config struct {
 	GlobalAdmins      []string
 	DBConnMaxLifetime time.Duration // max lifetime of a DB connection; 0 uses default (5m)
 	DBConnMaxIdleTime time.Duration // max idle time of a DB connection; 0 uses default (3m)
+	ShutdownTimeout   time.Duration // max time to wait for in-flight requests to drain on shutdown; 0 uses default (10s)
 }
 
 // ConfigFromEnv returns a Config populated from environment variables.
@@ -62,6 +68,7 @@ func ConfigFromEnv() Config {
 		GlobalAdmins:      globalAdminsFromString(os.Getenv("GADGET_GLOBAL_ADMINS")),
 		DBConnMaxLifetime: parseDurationEnv("GADGET_DB_CONN_MAX_LIFETIME"),
 		DBConnMaxIdleTime: parseDurationEnv("GADGET_DB_CONN_MAX_IDLE_TIME"),
+		ShutdownTimeout:   parseDurationEnv("GADGET_SHUTDOWN_TIMEOUT"),
 	}
 }
 
@@ -85,12 +92,13 @@ func parseDurationEnv(key string) time.Duration {
 type Middleware func(ctx router.HandlerContext, next func(router.HandlerContext))
 
 type Gadget struct {
-	Router        router.Router
-	Client        *slack.Client
-	UserClient    *slack.Client // nil if no user token configured
-	signingSecret string
-	listenPort    string
-	middleware    []Middleware
+	Router          router.Router
+	Client          *slack.Client
+	UserClient      *slack.Client // nil if no user token configured
+	signingSecret   string
+	listenPort      string
+	middleware      []Middleware
+	shutdownTimeout time.Duration
 }
 
 func requestLog(code int, r http.Request, denied bool, start time.Time, logger zerolog.Logger) {
@@ -243,6 +251,7 @@ func SetupWithConfig(cfg Config) (*Gadget, error) {
 	}
 	gadget.signingSecret = cfg.SigningSecret
 	gadget.listenPort = cfg.ListenPort
+	gadget.shutdownTimeout = cfg.ShutdownTimeout
 
 	log.Debug().Str("globalAdmins", strings.Join(cfg.GlobalAdmins, ", ")).Msg("Pulled globalAdmins")
 
@@ -538,16 +547,66 @@ func (gadget Gadget) Handler() http.Handler {
 	return mux
 }
 
+// Run starts the HTTP server and blocks until it exits. It listens for
+// SIGINT/SIGTERM and, on receipt, performs a graceful shutdown: in-flight
+// requests are given up to the configured ShutdownTimeout (default 10s,
+// via GADGET_SHUTDOWN_TIMEOUT) to complete before the server stops.
 func (gadget Gadget) Run() error {
-	handler := gadget.Handler()
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	return gadget.RunWithContext(ctx)
+}
+
+// RunWithContext starts the HTTP server and blocks until either it fails or
+// ctx is done, at which point it performs the same graceful shutdown as Run.
+// It's exposed separately from Run so callers (and tests) can trigger
+// shutdown without needing to send the process an OS signal.
+func (gadget Gadget) RunWithContext(ctx context.Context) error {
 	port := gadget.getListenPort()
+	ln, err := net.Listen("tcp", fmt.Sprintf(":%s", port))
+	if err != nil {
+		return fmt.Errorf("listen on port %s: %w", port, err)
+	}
+	return gadget.serve(ctx, ln, gadget.Handler())
+}
+
+// serve runs an HTTP server with the given handler on ln until ctx is done,
+// then gracefully shuts it down. Split out from RunWithContext so tests can
+// supply a listener bound to an ephemeral port and a synthetic handler to
+// exercise shutdown timing without needing a real Slack request.
+func (gadget Gadget) serve(ctx context.Context, ln net.Listener, handler http.Handler) error {
 	srv := &http.Server{
-		Addr:         fmt.Sprintf(":%s", port),
 		Handler:      handler,
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 10 * time.Second,
 		IdleTimeout:  60 * time.Second,
 	}
-	log.Info().Str("port", port).Msg("Server listening")
-	return srv.ListenAndServe()
+
+	errCh := make(chan error, 1)
+	go func() {
+		log.Info().Str("addr", ln.Addr().String()).Msg("Server listening")
+		if err := srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+			return
+		}
+		errCh <- nil
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		log.Info().Msg("Shutdown signal received, draining in-flight requests")
+		timeout := gadget.shutdownTimeout
+		if timeout == 0 {
+			timeout = 10 * time.Second
+		}
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			return fmt.Errorf("graceful shutdown: %w", err)
+		}
+		log.Info().Msg("Server shut down cleanly")
+		return nil
+	}
 }

--- a/core/shutdown_test.go
+++ b/core/shutdown_test.go
@@ -1,0 +1,148 @@
+package core
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func listenEphemeral(t *testing.T) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	return ln
+}
+
+func TestServe_ReturnsNilOnGracefulShutdown(t *testing.T) {
+	gadget := Gadget{}
+	ln := listenEphemeral(t)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- gadget.serve(ctx, ln, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+	}()
+
+	// Give the server a moment to start accepting connections.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("serve did not return after context cancellation")
+	}
+}
+
+func TestServe_DrainsInFlightRequestBeforeReturning(t *testing.T) {
+	gadget := Gadget{shutdownTimeout: 2 * time.Second}
+	ln := listenEphemeral(t)
+	addr := ln.Addr().String()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	handlerStarted := make(chan struct{})
+	releaseHandler := make(chan struct{})
+	handlerCompleted := make(chan struct{})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- gadget.serve(ctx, ln, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			close(handlerStarted)
+			<-releaseHandler
+			w.WriteHeader(http.StatusOK)
+			close(handlerCompleted)
+		}))
+	}()
+
+	// Fire a request that blocks inside the handler until we release it.
+	reqDone := make(chan struct{})
+	go func() {
+		resp, err := http.Get("http://" + addr) //nolint:noctx // test helper
+		if err == nil {
+			_ = resp.Body.Close()
+		}
+		close(reqDone)
+	}()
+
+	select {
+	case <-handlerStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler never started")
+	}
+
+	// Cancel while the request is still in flight, then release it shortly after.
+	cancel()
+	time.Sleep(50 * time.Millisecond)
+	select {
+	case <-handlerCompleted:
+		t.Fatal("handler completed before it was released")
+	default:
+	}
+	close(releaseHandler)
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err, "graceful shutdown should wait for the in-flight request to drain")
+	case <-time.After(2 * time.Second):
+		t.Fatal("serve did not return after in-flight request drained")
+	}
+
+	<-reqDone
+}
+
+func TestServe_ReturnsErrorWhenShutdownTimesOutWithSlowRequest(t *testing.T) {
+	gadget := Gadget{shutdownTimeout: 50 * time.Millisecond}
+	ln := listenEphemeral(t)
+	addr := ln.Addr().String()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	handlerStarted := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- gadget.serve(ctx, ln, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			close(handlerStarted)
+			time.Sleep(1 * time.Second) // longer than shutdownTimeout
+			w.WriteHeader(http.StatusOK)
+		}))
+	}()
+
+	go func() {
+		resp, err := http.Get("http://" + addr) //nolint:noctx // test helper
+		if err == nil {
+			_ = resp.Body.Close()
+		}
+	}()
+
+	select {
+	case <-handlerStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler never started")
+	}
+
+	cancel()
+
+	select {
+	case err := <-done:
+		assert.Error(t, err, "expected shutdown to time out while the slow request was still in flight")
+	case <-time.After(2 * time.Second):
+		t.Fatal("serve did not return after shutdown timeout should have elapsed")
+	}
+}
+
+func TestServe_DefaultsShutdownTimeoutWhenUnset(t *testing.T) {
+	gadget := Gadget{} // shutdownTimeout left at zero value
+	ln := listenEphemeral(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled; serve should shut down immediately
+
+	err := gadget.serve(ctx, ln, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## Summary

`Run()` previously called `srv.ListenAndServe()` directly with no signal handling — on SIGTERM/SIGINT (e.g. a container orchestrator stopping the pod) the process would die immediately, killing any in-flight requests.

- `Run()` now derives a context via `signal.NotifyContext(ctx, SIGINT, SIGTERM)` and delegates to a new `RunWithContext(ctx)`.
- On shutdown, in-flight requests get up to `ShutdownTimeout` (default `10s`) to complete via `http.Server.Shutdown()` before the server exits.
- `ShutdownTimeout` is configurable via `Config.ShutdownTimeout` / `GADGET_SHUTDOWN_TIMEOUT` (same `parseDurationEnv` pattern as the existing DB pool timeouts).
- Internals are split into `RunWithContext` (signal-free, context-driven) and an unexported `serve(ctx, listener, handler)` so shutdown timing can be tested deterministically — including a slow in-flight request that exceeds the timeout — without sending real OS signals or depending on a fixed port.

Docs: `CLAUDE.md` and the README demo env var list now mention `GADGET_SHUTDOWN_TIMEOUT`.

Closes #145

## Test plan

- [x] `make test` — full suite passes, including new `core/shutdown_test.go`:
  - graceful shutdown returns `nil` after context cancellation
  - an in-flight request is drained (server doesn't return until the handler finishes)
  - a request slower than `ShutdownTimeout` causes `serve` to return an error
  - unset `ShutdownTimeout` falls back to the 10s default
- [x] `make lint` — 0 issues
- [x] `make build` — binary builds
