### PR TITLE
ci: publish a GitHub Release automatically on version tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "${{ github.ref_name }}" --title "${{ github.ref_name }}" --generate-notes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,20 @@ Examples:
 - `feat!: rename SetupWithConfig to NewBot`
 - `chore: update golangci-lint to v1.57`
 
+## Releasing
+
+Gadget is consumed by other repos (Penny, gadget-plugin-*) via `go get`/`go.mod`, which resolves against git tags — not GitHub Releases. Publishing a Release is what makes a version visible/discoverable to humans browsing the repo.
+
+To cut a release:
+
+1. Ensure `main` is in the state you want to release.
+2. Tag it following semver, based on the conventional-commit types merged since the last tag: `fix`/`chore`/`docs`/etc → patch, `feat` → minor, anything with `!` or a `BREAKING CHANGE:` footer → major.
+   ```bash
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+3. The `.github/workflows/release.yml` workflow triggers on the tag push and automatically publishes a GitHub Release with auto-generated notes (`gh release create --generate-notes`) — no further action needed.
+
 ## GitHub Repository
 
 The origin repository is `gadget-bot/gadget`. Always use this owner/repo when querying GitHub for issues, milestones, pull requests, or other repository details.


### PR DESCRIPTION
## Summary

Tags exist (up through v0.8.1) but nobody was turning them into GitHub Release objects — the Releases page was stuck at v0.2.3, which is confusing for anyone browsing the repo rather than pinning via `go.mod`. (Already backfilled Releases for the existing v0.3.0–v0.8.1 tags separately.)

This closes the gap going forward:

- New `.github/workflows/release.yml` triggers on `push: tags: v*` and runs `gh release create "$TAG" --generate-notes`, so any future tag automatically gets a published Release with auto-generated notes — no manual step required.
- `CLAUDE.md` gets a new **Releasing** section documenting the convention: tag `main` following semver based on conventional-commit types since the last tag, push the tag, the workflow does the rest.

Closes #146

## Test plan

- [ ] After merge, push a test tag (or the next real release tag) and confirm the `Release` workflow run publishes a Release with generated notes.
